### PR TITLE
Add initial tox support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+    - 2.7
+
+notifications:
+    email: false
+
+before_install:
+    - pip install pep8
+    - pip install misspellings
+    - pip install nose
+
+script:
+    # Run pep8 on all .py files in all subfolders
+    # (I ignore "E402: module level import not at top of file"
+    # because of use case sys.path.append('..'); import <module>)
+    - find . -name \*.py -exec pep8 --ignore=E402,E501 {} +
+    - find . -name '*.py' | misspellings -f -
+    - nosetests
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+configparser
+urwid
+paramiko

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+minversion = 2.0
+envlist = py27,pep8
+skipsdist = True
+
+[testenv]
+passenv = CI TRAVIS TRAVIS_*
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+commands = 
+	/usr/bin/find . -type f -name "*.pyc" -delete
+	nosetests \
+		[]
+[testenv:pep8]
+commands = flake8
+
+[testenv:venv]
+commands = {posargs}
+
+[testenv:cover]
+commands =
+  coverage report
+
+[flake8]
+show-source = True
+exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build
+


### PR DESCRIPTION
This will allow to execute `tox -e pep8` or `tox -e py27` to implement unit testing and pep8 validation to the code.

Also `.travis.yml` is included to allow automatic validation via <https://travis-ci.org> once the repo is enabled there.

Python requirements documented on `README.md` have been defined in `requirements.txt` and `test-requirements.txt`