### PR TITLE
Add Password Support

### DIFF
--- a/SSHClient.py
+++ b/SSHClient.py
@@ -45,11 +45,19 @@ class SSHClient(Client):
 		transport.start_client()
 		return transport
 
-	def start_session(self, user, private_key):
+	def start_session(self, user, auth_secret):
 		logging.debug("SSHClient: Authenticating using private key")
 		try:
 			transport = self.get_transport()
-			transport.auth_publickey(user, private_key)
+			# We get this if the `auth_secret` is a string instead
+			# of the object type for an SSH key.  Use this to try
+			# password authentication.  This is possible if there
+			# is no public SSH key for the user on the Aker
+			# gateway.
+			if isinstance(auth_secret, basestring):
+				transport.auth_password(user, auth_secret)
+			else:
+				transport.auth_publickey(user, auth_secret)
 			self._start_session(transport)
 		except Exception as e:
 			logging.error(e)

--- a/session.py
+++ b/session.py
@@ -7,7 +7,7 @@
 __license__ = "AGPLv3"
 __author__ = 'Ahmed Nazmy <ahmed@nazmy.io>'
 
-
+import getpass
 import logging
 import signal
 import os
@@ -56,5 +56,13 @@ class SSHSession(Session):
 
 		
 	def start_session(self):
-		priv_key = self.aker.user.get_priv_key()
-		self._client.start_session(self.host_user,priv_key)
+		try:
+			auth_secret = self.aker.user.get_priv_key()
+		# currently, if no SSH public key exists, an ``Exception``
+		# is raised.  Catch it and try a password.
+		except Exception as exc:
+			if str(exc) == 'Core: Invalid Private Key':
+				auth_secret = getpass.getpass("Password: ")
+			else:
+				raise
+		self._client.start_session(self.host_user, auth_secret)


### PR DESCRIPTION
This fixes #11 in a slightly different manner than originally outlined.  Instead of requiring a user to specify that he or she desires password authentication in the `aker.ini` config, we assume SSH private keys _first_, and then we automatically fail back to password-based authentication only if SSH key authentication fails.

The reason for the change in implementation is the (admittedly late) realization that SSH keys might be used for some remote systems but not all of them.  If, for example, a company is using Aker to manage their Linux servers and myriad network or embedded devices, they might use SSH keys for the Linux servers but passwords for the network and embedded devices.  My original suggested implementation would have required separate Aker installations for each use case.  This implementation allows them to be combined while gracefully handling failures of SSH key authentication in multiple cases.