### PR TITLE
Add setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/README.md
+++ b/README.md
@@ -45,15 +45,12 @@ Python Modules:
 
 
 ### Installation
-* First the dependencies 
-~~~
-yum install python2-paramiko python-configparser python-urwid
-~~~
+* Install `aker`:
+```
+pip install git+https://github.com/aker-gateway/Aker
+```
 
-* Copying files
-```
-cp *.py /bin/aker/
-```
+> This will change once Aker is pushed to PyPI.
 
 * Copy aker.ini in /etc/ and edit it to include users and servers like below :
 ```
@@ -74,14 +71,14 @@ hosts = websrv1.example.com,22,root
 
 ```
 
-* Add `/bin/aker/aker.py` to /etc/shells 
+* Add `aker` to /etc/shells 
 ```
-echo "/bin/aker/aker.py" >> /etc/shells 
+echo "$(which aker)" >> /etc/shells 
 ```
 
-* Change user shell to aker
+* Change user shell to `aker`
 ```
-chsh -s /bin/aker/aker.py username
+chsh -s $(which aker) username
 ```
 
 ### Contributing

--- a/aker/SSHClient.py
+++ b/aker/SSHClient.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 #       Copyright 2016 Ahmed Nazmy
-#
-
-# Meta
 import getpass
 import logging
 import os
@@ -16,8 +13,6 @@ import tty
 
 import paramiko
 
-__license__ = "AGPLv3"
-__author__ = 'Ahmed Nazmy <ahmed@nazmy.io>'
 
 TIME_OUT = 10
 

--- a/aker/__init__.py
+++ b/aker/__init__.py
@@ -1,0 +1,15 @@
+"""Aker SSH Gateway."""
+__version__ = '0.2.3'
+__version_info__ = (0, 2, 3)
+__license__ = "AGPLv3"
+__license_info__ = {
+    "AGPLv3": {
+        "product": "aker",
+        "users": 0,  # 0 being unlimited
+        "customer": "Unsupported",
+        "version": __version__,
+        "license_format": "1.0",
+    }
+}
+__author__ = 'Ahmed Nazmy'
+__author_email__ = 'ahmed@nazmy.io'

--- a/aker/aker.py
+++ b/aker/aker.py
@@ -4,9 +4,7 @@
 #       Copyright 2016 ahmed@nazmy.io
 #
 # For license information see LICENSE.txt
-
-
-# Meta
+from __future__ import absolute_import
 from configparser import ConfigParser
 import getpass
 import logging
@@ -16,22 +14,10 @@ import uuid
 
 import paramiko
 
-import tui
-from session import SSHSession
-from snoop import Sniffer
+import aker.tui
+from aker.session import SSHSession
+from aker.snoop import Sniffer
 
-__version__ = '0.2.2'
-__version_info__ = (0, 2, 2)
-__license__ = "AGPLv3"
-__license_info__ = {
-    "AGPLv3": {
-        "product": "aker",
-        "users": 0,  # 0 being unlimited
-        "customer": "Unsupported",
-        "version": __version__,
-        "license_format": "1.0",
-    }
-}
 
 config_file = "/etc/aker.ini"
 log_file = 'aker.log'
@@ -102,7 +88,7 @@ class Aker(object):
 
     def build_tui(self):
         logging.debug("Core: Drawing TUI")
-        self.tui = tui.Window(self)
+        self.tui = aker.tui.Window(self)
         self.tui.draw()
         self.tui.start()
 

--- a/aker/aker.py
+++ b/aker/aker.py
@@ -124,5 +124,10 @@ class Aker(object):
                      .format(session.uuid, self.posix_user, session.host))
 
 
-if __name__ == '__main__':
+def main():
+    """Entrypoint for Aker."""
     Aker().build_tui()
+
+
+if __name__ == '__main__':
+    main()

--- a/aker/session.py
+++ b/aker/session.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 #       Copyright 2016 Ahmed Nazmy
-#
+from __future__ import absolute_import
 import getpass
 import logging
 import os
 import signal
 
-from SSHClient import SSHClient
-
-__license__ = "AGPLv3"
-__author__ = 'Ahmed Nazmy <ahmed@nazmy.io>'
+from aker.SSHClient import SSHClient
 
 
 class Session(object):

--- a/aker/snoop.py
+++ b/aker/snoop.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 #
 #       Copyright 2016 Ahmed Nazmy
-#
 import logging
 import os
 from Queue import Queue
 import stat
 import threading
 import sys
-
-__license__ = "AGPLv3"
-__author__ = 'Ahmed Nazmy <ahmed@nazmy.io>'
 
 
 class Sniffer(object):

--- a/aker/tui.py
+++ b/aker/tui.py
@@ -6,9 +6,6 @@ import logging
 
 import urwid
 
-__license__ = "AGPLv3"
-__author__ = 'Ahmed Nazmy <ahmed@nazmy.io>'
-
 
 class MenuItem(urwid.Text):
     def __init__(self, caption):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+"""Setup for inspector."""
+import os
+from setuptools import setup
+
+from aker import __author__, __author_email__, __license__, __version__
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+setup(
+    name='aker',
+    version=__version__,
+    description='Aker SSH Gateway',
+    long_description=read('README.md'),
+    url='http://github.com/aker-gateway/Aker',
+    author=__author__,
+    author_email=__author_email__,
+    license=__license__,
+    packages=['aker'],
+    install_requires=['configparser', 'urwid', 'paramiko'],
+    zip_safe=False
+)

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
     license=__license__,
     packages=['aker'],
     install_requires=['configparser', 'urwid', 'paramiko'],
-    zip_safe=False
+    zip_safe=False,
+    entry_points={'console_scripts': ['aker = aker.aker:main']}
 )


### PR DESCRIPTION
Reorganizes code and adds a `setup.py`.  `aker` can now be installed with `pip`.  Also bumps the version to `0.2.3` and updates the `README.md`.  Finally, uses `setup.py`'s `entry_points` to create the script that starts `aker` instead of relying on executing the Python module directly.