### PR TITLE
Add a trap for CTRL-C

### DIFF
--- a/aker.py
+++ b/aker.py
@@ -29,12 +29,18 @@ import paramiko
 import socket
 from configparser import ConfigParser, NoOptionError
 import time
+import signal
+import sys
 
 from hosts import Hosts
 import tui
 from session import SSHSession
 from snoop import SSHSniffer
 
+def signal_handler(signal, frame):
+        logging.debug("Core: user tried an invalid signal {}".format(signal))
+# Capture CTRL-C
+signal.signal(signal.SIGINT, signal_handler)
 
 config_file = "/etc/aker/aker.ini"
 log_file = '/var/log/aker/aker.log'


### PR DESCRIPTION
Added a trap for CTRL-C as it creates a traceback without trapping.

`Traceback (most recent call last):
  File "/usr/bin/aker/aker.py", line 169, in <module>
    Aker().build_tui()
  File "/usr/bin/aker/aker.py", line 131, in build_tui
    self.tui.start()
  File "/usr/bin/aker/tui.py", line 349, in start
    self.loop.run()
  File "/usr/lib64/python2.7/site-packages/urwid/main_loop.py", line 271, in run
    self.screen.run_wrapper(self._run)
  File "/usr/lib64/python2.7/site-packages/urwid/raw_display.py", line 241, in run_wrapper
    return fn()
  File "/usr/lib64/python2.7/site-packages/urwid/main_loop.py", line 336, in _run
    self.event_loop.run()
  File "/usr/lib64/python2.7/site-packages/urwid/main_loop.py", line 707, in run
    self._loop()
  File "/usr/lib64/python2.7/site-packages/urwid/main_loop.py", line 773, in _loop
    ready, w, err = select.select(fds, [], fds)
KeyboardInterrupt
Connection to XXXX closed.
`

In the diff, I am writing a log message on the signal, but doing nothing else.