### PR TITLE
Fixed a few crashes that would happen due to unhandled exceptions

### DIFF
--- a/session.py
+++ b/session.py
@@ -70,4 +70,7 @@ class SSHSession(Session):
                 auth_secret = getpass.getpass("Password: ")
             else:
                 raise
-        self._client.start_session(self.host_user, auth_secret)
+        try:
+            self._client.start_session(self.host_user, auth_secret)
+        except:
+            logging.debug("Session: SSHSession failed")

--- a/snoop.py
+++ b/snoop.py
@@ -161,9 +161,12 @@ class Sniffer(object):
                 "Sniffer: close session files error {0} ".format(
                     e.message))
 
-        self.log_file.write('Session End %s' % session_end)
-        self.log_file.close()
-        self.log_timer.close()
+        try:
+            self.log_file.write('Session End %s' % session_end)
+            self.log_file.close()
+            self.log_timer.close()
+        except:
+            logging.debug("Sniffer: Failed to close files. Likely due to a session close before establishing.")
 
 
 class SSHSniffer(Sniffer):

--- a/tui.py
+++ b/tui.py
@@ -70,10 +70,11 @@ class HostList(Listing):
 
     def keypress(self, size, key):
         if key == 'enter':
-            urwid.emit_signal(
-                self,
-                'connect',
-                self.focus.original_widget.get_caption())
+            if self.focus is not None:
+                urwid.emit_signal(
+                    self,
+                    'connect',
+                    self.focus.original_widget.get_caption())
             key = None
         elif key == 'esc':
             self.search.clear()
@@ -98,10 +99,11 @@ class HostGroupList(Listing):
         if key == 'enter':
             # emit signal to call hostgroup_chosen_handler with MenuItem caption,
             # caption is group name showing on screen
-            urwid.emit_signal(
-                self,
-                'group_chosen',
-                self.focus.original_widget.get_caption())
+            if self.focus is not None:
+                urwid.emit_signal(
+                    self,
+                    'group_chosen',
+                    self.focus.original_widget.get_caption())
             key = None
         elif key == 'esc':
             self.search.clear()


### PR DESCRIPTION
Handling a couple exceptions to avoid a crash:
* Catch exception on cancelling a new session at the "Password: " prompt.
* Catch exception on hitting "enter" when a search is invalid.